### PR TITLE
package: add "component" section

### DIFF
--- a/package.json
+++ b/package.json
@@ -15,5 +15,10 @@
     "cross-browser"
   ],
   "author": "Jakeb Rosoman",
-  "license": "MIT"
+  "license": "MIT",
+  "component": {
+    "scripts": {
+      "computed-style/index.js": "index.js"
+    }
+  }
 }


### PR DESCRIPTION
The old build system we're currently using (not `component build`)
requires this "component" section to be defined in the package.json
file.
