### PR TITLE
Fix Problem in IE11 (invalid calling object)

### DIFF
--- a/index.js
+++ b/index.js
@@ -9,7 +9,7 @@
  */
 
 // Accessing via window for jsDOM support
-module.exports = window.getComputedStyle
+module.exports = window.getComputedStyle.bind(window)
 
 // Fallback to elem.currentStyle for IE < 9
 if (!module.exports) {


### PR DESCRIPTION
It seems that IE does not bind the window object correctly if we just do `module.export = window.getComputedStyle` ... so we explicity bind it thus solving the IE Problem
